### PR TITLE
ParserRuleContext.getChildCount() now returns 0 if self.children is None

### DIFF
--- a/src/antlr4/ParserRuleContext.py
+++ b/src/antlr4/ParserRuleContext.py
@@ -168,7 +168,7 @@ class ParserRuleContext(RuleContext):
         return contexts
 
     def getChildCount(self):
-        return len(self.children)
+        return len(self.children) if self.children else 0
 
     def getSourceInterval(self):
         if self.start is None or self.stop is None:


### PR DESCRIPTION
Otherwise, you get the following error when a listener executes ctx.getText() on a rule that allows a blank line:
    TypeError: object of type 'NoneType' has no len()