### PR TITLE
Added optional predicate parameter to ParserRuleContext.getChildren(), a...

### DIFF
--- a/src/antlr4/ParserRuleContext.py
+++ b/src/antlr4/ParserRuleContext.py
@@ -113,21 +113,21 @@ class ParserRuleContext(RuleContext):
         node.parentCtx = self
         return node
 
-    def getChild(self, i, type = None):
-        if type is None:
+    def getChild(self, i, ttype = None):
+        if ttype is None:
             return self.children[i] if len(self.children)>=i else None
         else:
             for child in self.getChildren():
-                if not isinstance(child, type):
+                if not isinstance(child, ttype):
                     continue
                 if i==0:
                     return child
                 i -= 1
             return None
 
-    def getChildren(self):
+    def getChildren(self, predicate = None):
         if self.children is not None:
-            for child in self.children:
+            for child in (self.children if predicate is None else [x for x in self.children if predicate(x)]):
                 yield child
 
     def getToken(self, ttype, i):


### PR DESCRIPTION
...nd renamed param in getChild() to avoid warning (type is reserved)