### PR TITLE
Fix for issue #46: bug in getChild() in ParserRuleContext.

### DIFF
--- a/src/antlr4/ParserRuleContext.py
+++ b/src/antlr4/ParserRuleContext.py
@@ -115,7 +115,7 @@ class ParserRuleContext(RuleContext):
 
     def getChild(self, i, ttype = None):
         if ttype is None:
-            return self.children[i] if len(self.children)>=i else None
+            return self.children[i] if len(self.children)>i else None
         else:
             for child in self.getChildren():
                 if not isinstance(child, ttype):


### PR DESCRIPTION
ParserRuleContext.getChild() attempts to read past the end of the list of children when called with i=len(self.children). The fix is trivial. This appears to be the only place in the source where this issue manifests. 