### PR TITLE
Added optional 'types' arg to ParserRuleContext.getChildren()

### DIFF
--- a/src/antlr4/ParserRuleContext.py
+++ b/src/antlr4/ParserRuleContext.py
@@ -125,10 +125,13 @@ class ParserRuleContext(RuleContext):
                 i -= 1
             return None
 
-    def getChildren(self, ttype = None, predicate = None):
+    def getChildren(self, ttype = None, predicate = None, types = None):
         if self.children is not None:
             for child in self.children:
                 if ttype is not None and not isinstance(child, ttype):
+                    continue
+
+                if types is not None and not any(x for x in types if isinstance(child, x)):
                     continue
 
                 if predicate is not None and not predicate(child):


### PR DESCRIPTION
This makes it easier to filter the children based on a list of types, instead of having to use the 'predicate' arg with several 'isinstance() or isinstance()' function calls.  For example:

````
children_to_process = ctx.getChildren(types = [myParser.ThisContext, myParser.ThatContext])]

````

-Larry
